### PR TITLE
Add Docker Image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,35 @@
+FROM pytorch/pytorch:2.3.1-cuda11.8-cudnn8-runtime
+
+LABEL authors="Colby T. Ford <colby@tuple.xyz>"
+
+## Install system requirements
+RUN apt update && \
+    apt-get install -y --reinstall \
+        ca-certificates && \
+    apt install -y \
+        git \
+        wget \
+        gcc \
+        g++
+
+## Set working directory
+RUN mkdir -p /software/appt
+WORKDIR /software/appt
+
+## Clone project
+RUN git clone https://github.com/Bindwell/APPT /software/appt 
+
+## Install Python requirements
+RUN pip install -r requirements.txt
+
+## Download caches.pt from Hugging Face
+RUN mkdir embedding_cache_2560 && \
+    cd embedding_cache_2560 && \
+    wget https://huggingface.co/Bindwell/APPT/resolve/main/caches.pt?download=true \
+        -O caches.pt
+
+## Download model from Hugging Face
+RUN mkdir models && \
+    cd models && \
+    wget https://huggingface.co/Bindwell/APPT/resolve/main/protein_protein_affinity_esm_vs_ankh_best.pt?download=true \
+        -O protein_protein_affinity_esm_vs_ankh_best.pt

--- a/README.md
+++ b/README.md
@@ -43,6 +43,30 @@ conda activate bindwell_appt
    python cli.py --sequences ABC DEF
    ```
 
+## Docker
+
+You can also run the model using Docker:
+
+1. Build the Docker image locally:
+
+   ```bash
+   docker build -t appt .
+   ```
+
+   Or pull the pre-built image from Docker Hub:
+
+   ```bash
+   docker pull cford38/appt:latest
+   ```
+
+2. Run the Docker container:
+
+   ```bash
+   docker run --gpus all --rm --name appt -it appt /bin/bash
+   # docker run --gpus all --rm --name appt -it cford38/appt:latest /bin/bash
+   ```
+
+
 ## Performance Evaluation
 
 Our model demonstrates superior performance compared to existing methods across multiple metrics:

--- a/cli.py
+++ b/cli.py
@@ -1,4 +1,4 @@
-import os
+import os, json
 import argparse
 import pandas as pd
 import torch


### PR DESCRIPTION
This PR includes a basic Dockerfile for running APPT in a container. It comes preconfigured with the required Python dependencies, CUDA drivers, model and `caches.pt` files from Hugging Face, etc.


### To Use

```bash
docker build -t appt .

docker run --gpus all --rm --name appt -it appt /bin/bash
python cli.py ...
```


This image is prebuilt and hosted on Docker Hub (at https://hub.docker.com/repository/docker/cford38/appt) and can be pulled using `docker pull cford38/appt:latest`.


Also, in a future version of this image, we could pre-download the model `.bin` files (~9GB) to reduce the time for the initial inferencing.